### PR TITLE
Spicy GH-1468 for IEC60870-5-104 parser 

### DIFF
--- a/IEC60870-5-104/README.md
+++ b/IEC60870-5-104/README.md
@@ -6,7 +6,7 @@ IEC 60870-5-104 Parser - Network access for IEC 60870-5-101 using standard trans
 
 IEC60870_5_104 is a Zeek plugin (written in [Spicy](https://docs.zeek.org/projects/spicy/en/latest/)) for parsing and logging fields used by the IEC 60870-5-104 protocol as presented in the standard IEC 60870-5-104:2006 and IEC 60870-5-101:2003, defining a transmission format for sending and receiving SCADA data in power systems.
 
-This parser produces the following log files, defined in [scripzs/main.zeek](scripts/main.zeek):
+This parser produces the following log files, defined in [scripts/main.zeek](scripts/main.zeek):
 
 * `104.log`
 

--- a/IEC60870-5-104/README.md
+++ b/IEC60870-5-104/README.md
@@ -26,67 +26,102 @@ If this package is installed from `zkg` it will be added to the available plugin
 
 If you have `zkg` configured to load packages (see `@load packages` in the [`zkg` Quickstart Guide](https://docs.zeek.org/projects/package-manager/en/stable/quickstart.html)), this plugin and scripts will automatically be loaded and ready to go.
 
+### Test
+
+The script can tested immideatly with
+
+```bash
+$ zeek -r <pcapfile> iec60870_5_104.hlto ./scripts/main.zeek 
+Initializing IEC 60870-5-104 analyzer
+```
+
+Now, in the folder lies an `conn.log`and the application log `iec_104.log`.
+
+## Finalize installation
+
+In order to including the parser into zeeks scripting land the folder has to copy into zeek. In the follwing example the installation path to zeek is`/opt/`
+
+```bash
+cd /opt/zeek/share/zeek/base/protocols
+sudo mkdir iec60870-5-104/
+cp <path_to_folder IEC60870-5-104>/scripts/* opt/zeek/share/zeek/base/protocols/iec60870-5-104/
+cd /opt/zeek/share/zeek/base/
+<texteditor> init-default.zeek
+```
+
+```bash
+# <insert a command if you want here>
+@load base/protocols/iec60870-5-104
+```
+
+Idealy, the line is inserted where the other base protocols are listed. An command can be included by using the # sign.
+
 ## Protocol support and limitations
 
 This parser has implemented and tested the following message types according to the IEC 60870-5-104 standard (see IEC 60870-5-104: 6 Auswahl von ASDU aus IEC 60870-5-101 und zusätzliche ASDU):
 
 | ASDU type (ASDU ID)    | Implemented    | Tested         |
 | ---------------------- |----------------|----------------|
-| M_SP_NA_1 (1)          | Yes            | Yes            |
-| M_DP_NA_1 (3)          | Yes            | Yes            |
-| M_ST_NA_1 (5)          | Yes            | Yes            |
-| M_BO_NA_1 (7)          | Yes            | Limited        |
-| M_ME_NA_1 (9)          | Yes            | Yes            |
-| M_ME_NB_1 (11)         | Yes            | Yes            |
-| M_ME_NC_1 (13)         | Yes            | Yes            |
-| M_IT_NA_1 (15)         | Yes            | No             |
-| M_PS_NA_1 (20)         | Yes            | No             |
-| M_ME_ND_1 (21)         | Yes            | No             |
-| M_SP_TB_1 (30)         | Yes            | Yes            |
-| M_DP_TB_1 (31)         | Yes            | Yes            |
-| M_ST_TB_1 (32)         | Yes            | Yes            |
-| M_BO_TB_1 (33)         | Yes            | Limited        |
-| M_ME_TD_1 (34)         | Yes            | Yes            |
-| M_ME_TE_1 (35)         | Yes            | Yes            |
-| M_ME_TF_1 (36)         | Yes            | Yes            |
-| M_IT_TB_1 (37)         | Yes            | No             |
-| M_EP_TD_1 (38)         | Yes            | No             |
-| M_EP_TE_1 (39)         | Yes            | No             |
-| M_EP_TF_1 (40)         | Yes            | No             |
-| C_SC_NA_1 (45)         | Yes            | Limited        |
-| C_DC_NA_1 (46)         | Yes            | Limited        |
-| C_RC_NA_1 (47)         | Yes            | Limited        |
-| C_SE_NA_1 (48)         | Yes            | No             |
-| C_SE_NB_1 (49)         | Yes            | No             |
-| C_SE_NC_1 (50)         | Yes            | No             |
-| C_BO_NA_1 (51)         | Yes            | Limited        |
-| C_SC_TA_1 (58)         | Yes            | No             |
-| C_DC_TA_1 (59)         | Yes            | No             |
-| C_RC_TA_1 (60)         | Yes            | No             |
-| C_SE_TA_1 (61)         | Yes            | No             |
-| C_SE_TB_1 (62)         | Yes            | No             |
-| C_SE_TC_1 (63)         | Yes            | No             |
-| C_BO_TA_1 (64)         | Yes            | Limited        |
-| M_EI_NA_1 (70)         | Yes            | Yes            |
-| C_IC_NA_1 (100)        | Yes            | Yes            |
-| C_CI_NA_1 (101)        | Yes            | Yes            |
-| C_RD_NA_1 (102)        | Yes            | No             |
-| C_CS_NA_1 (103)        | Yes            | No             |
-| C_TS_NA_1 (104)        | Yes            | No             |
-| C_RP_NA_1 (105)        | Yes            | No             |
-| C_CD_NA_1 (106)        | Yes            | No             |
-| C_TS_TA_1 (107)        | Yes            | No             |
-| P_ME_NA_1 (110)        | Yes            | No             |
-| P_ME_NB_1 (111)        | Yes            | No             |
-| P_ME_NC_1 (112)        | Yes            | No             |
-| P_AC_NA_1 (113)        | Yes            | No             |
-| F_FR_NA_1 (120)        | Yes            | No             |
-| F_SR_NA_1 (121)        | Yes            | No             |
-| F_SC_NA_1 (122)        | Yes            | No             |
-| F_LS_NA_1 (123)        | Yes            | No             |
-| F_AF_NA_1 (124)        | Yes            | No             |
-| F_SG_NA_1 (125)        | Yes            | No             |
-| F_DR_TA_1 (126)        | Yes            | No             |
+| M_SP_NA_1 (1)          | Fully          | Yes            |
+| M_DP_NA_1 (3)          | Fully          | Yes            |
+| M_ST_NA_1 (5)          | Fully          | Yes            |
+| M_BO_NA_1 (7)          | Fully          | Limited        |
+| M_ME_NA_1 (9)          | Fully          | Yes            |
+| M_ME_NB_1 (11)         | Fully          | Yes            |
+| M_ME_NC_1 (13)         | Fully          | Yes            |
+| M_IT_NA_1 (15)         | Partially      | No             |
+| M_PS_NA_1 (20)         | Partially      | No             |
+| M_ME_ND_1 (21)         | Partially      | No             |
+| M_SP_TB_1 (30)         | Fully          | Yes            |
+| M_DP_TB_1 (31)         | Fully          | Yes            |
+| M_ST_TB_1 (32)         | Fully          | Yes            |
+| M_BO_TB_1 (33)         | Fully          | Limited        |
+| M_ME_TD_1 (34)         | Fully          | Yes            |
+| M_ME_TE_1 (35)         | Fully          | Yes            |
+| M_ME_TF_1 (36)         | Fully          | Yes            |
+| M_IT_TB_1 (37)         | Partially      | No             |
+| M_EP_TD_1 (38)         | Partially      | No             |
+| M_EP_TE_1 (39)         | Partially      | No             |
+| M_EP_TF_1 (40)         | Partially      | No             |
+| C_SC_NA_1 (45)         | Fully          | Limited        |
+| C_DC_NA_1 (46)         | Fully          | Limited        |
+| C_RC_NA_1 (47)         | Fully          | Limited        |
+| C_SE_NA_1 (48)         | Partially      | No             |
+| C_SE_NB_1 (49)         | Fully          | Limited        |
+| C_SE_NC_1 (50)         | Partially      | No             |
+| C_BO_NA_1 (51)         | Fully          | Limited        |
+| C_SC_TA_1 (58)         | Partially      | No             |
+| C_DC_TA_1 (59)         | Partially      | No             |
+| C_RC_TA_1 (60)         | Partially      | No             |
+| C_SE_TA_1 (61)         | Partially      | No             |
+| C_SE_TB_1 (62)         | Partially      | No             |
+| C_SE_TC_1 (63)         | Partially      | No             |
+| C_BO_TA_1 (64)         | Fully          | Limited        |
+| M_EI_NA_1 (70)         | Fully          | Yes            |
+| C_IC_NA_1 (100)        | Fully          | Yes            |
+| C_CI_NA_1 (101)        | Fully          | Yes            |
+| C_RD_NA_1 (102)        | Fully          | Limited        |
+| C_CS_NA_1 (103)        | Partially      | No             |
+| C_TS_NA_1 (104)        | Partially      | No             |
+| C_RP_NA_1 (105)        | Fully          | Limited*       |
+| C_CD_NA_1 (106)        | Partially      | No             |
+| C_TS_TA_1 (107)        | Partially      | No             |
+| P_ME_NA_1 (110)        | Partially      | No             |
+| P_ME_NB_1 (111)        | Partially      | No             |
+| P_ME_NC_1 (112)        | Partially      | No             |
+| P_AC_NA_1 (113)        | Partially      | No             |
+| F_FR_NA_1 (120)        | Partially      | No             |
+| F_SR_NA_1 (121)        | Partially      | No             |
+| F_SC_NA_1 (122)        | Partially      | No             |
+| F_LS_NA_1 (123)        | Partially      | No             |
+| F_AF_NA_1 (124)        | Partially      | No             |
+| F_SG_NA_1 (125)        | Partially      | No             |
+| F_DR_TA_1 (126)        | Partially      | No             |
+
+Legend for column *Implemented*:\
+
+* Fully  &emsp; &nbsp; events are triggered
+* Partially &nbsp;events not given
 
 Legend for column *Test*:\
 The parser was tested
@@ -169,6 +204,7 @@ This log summarizes, by connection, IEC 60870-5-104 frames transmitted over 2404
 | cp56_year              | vector\<int>    | CP56 time object: year 0-9999                        |
 | cp56_su                | vector\<bool>   | CP56 time object: summer time                        |
 | cp56_valid             | vector\<bool>   | CP56 time object: validity                           |
+| qrp                    | vector\<string> | Qualifier of reset process                           |
 
 #### Community ID
 

--- a/IEC60870-5-104/analyzer/iec60870_5_104.evt
+++ b/IEC60870-5-104/analyzer/iec60870_5_104.evt
@@ -56,3 +56,8 @@ on IEC60870_5_104::IE if ( asdu_id==70 ) -> event iec60870_5_104::M_EI_NA_1($con
 on IEC60870_5_104::IE if ( asdu_id==100 ) -> event iec60870_5_104::C_IC_NA_1($conn, self.qoi.stationinterrogation, self.qoi.qoi);
 
 on IEC60870_5_104::IE if ( asdu_id==101 ) -> event iec60870_5_104::C_CI_NA_1($conn, self.qcc.nocounter, self.qcc.group1counter, self.qcc.group2counter, self.qcc.group3counter, self.qcc.group4counter, self.qcc.generalcounter, self.qcc.readonly, self.qcc.freeze, self.qcc.reset, self.qcc.freezeandreset);
+
+on IEC60870_5_104::IE if ( asdu_id==102 ) -> event iec60870_5_104::C_RD_NA_1($conn, self.read_cmd);
+
+#on IEC60870_5_104::IE if ( asdu_id==105 ) -> event iec60870_5_104::C_RP_NA_1($conn, self.qrp.qrp);
+on IEC60870_5_104::IE if ( asdu_id==105 ) -> event iec60870_5_104::C_RP_NA_1($conn, self.read_cmd_2, self.qrp.qrp);

--- a/IEC60870-5-104/analyzer/iec60870_5_104.evt
+++ b/IEC60870-5-104/analyzer/iec60870_5_104.evt
@@ -45,6 +45,8 @@ on IEC60870_5_104::IE if ( asdu_id==46 ) -> event iec60870_5_104::C_DC_NA_1($con
 
 on IEC60870_5_104::IE if ( asdu_id==47 ) -> event iec60870_5_104::C_RC_NA_1($conn, self.rco.increment, self.rco.decrement, self.rco.notallowed0, self.rco.notallowed3, self.rco.shortpulse, self.rco.longpulse, self.rco.persistent, self.rco.execute, self.rco.select);
 
+on IEC60870_5_104::IE if ( asdu_id==49 ) -> event iec60870_5_104::C_SE_NB_1($conn, self.sva.sva, self.qos.execute, self.qos.select);
+
 on IEC60870_5_104::IE if ( asdu_id==51 ) -> event iec60870_5_104::C_BO_NA_1($conn, self.bsi.bits);
 
 #on IEC60870_5_104::IE if ( asdu_id==64 ) -> event iec60870_5_104::C_BO_TA_1($conn, self.bsi.bits, self.cp56time.minutes, self.cp56time.hours, self.cp56time.day, self.cp56time.dow, self.cp56time.month, self.cp56time.year, self.cp56time.su, self.cp56time.valid);

--- a/IEC60870-5-104/analyzer/iec60870_5_104.spicy
+++ b/IEC60870-5-104/analyzer/iec60870_5_104.spicy
@@ -649,7 +649,6 @@ type IE = unit (asdu_id: uint8) {
 		}
 
 		# Get reset process command (C_RP_NA_1) --> not tested!
-		# Is that C_RP_NA_1 or C_RP_NC_1?
 		asdu_type::C_RP_NA_1 -> {
 
 			var read_cmd_2: bool = True;

--- a/IEC60870-5-104/analyzer/iec60870_5_104.spicy
+++ b/IEC60870-5-104/analyzer/iec60870_5_104.spicy
@@ -1064,7 +1064,7 @@ type FRQ = unit{
 type LOS = unit{
 
 	# Declarations
-	var size: uint8;
+	# var size: uint8; #1 - temp fix (?)
 
 	# Get length of segment (LOS)
 	: bitfield(8) {
@@ -1106,7 +1106,7 @@ type LSQ = unit{
 type NOF = unit{
 
 	# Declarations
-	var name: int16;
+	# var name: int16; #1 - temp fix (?)
 
 	# Get name of file (NOF)
 	: bitfield(16) {
@@ -1119,7 +1119,7 @@ type NOF = unit{
 type NOS = unit{
 
 	# Declarations
-	var name: int8;
+	# var name: int8; #1 - temp fix (?)
 
 	# Get name of section (NOS)
 	: bitfield(8) {

--- a/IEC60870-5-104/analyzer/iec60870_5_104.spicy
+++ b/IEC60870-5-104/analyzer/iec60870_5_104.spicy
@@ -649,7 +649,10 @@ type IE = unit (asdu_id: uint8) {
 		}
 
 		# Get reset process command (C_RP_NA_1) --> not tested!
+		# Is that C_RP_NA_1 or C_RP_NC_1?
 		asdu_type::C_RP_NA_1 -> {
+
+			var read_cmd_2: bool = True;
 
 			# Qualifier of reset process command
 			qrp: QRP;

--- a/IEC60870-5-104/cmake/FindSpicyPlugin.cmake
+++ b/IEC60870-5-104/cmake/FindSpicyPlugin.cmake
@@ -71,30 +71,29 @@ if (SPICYZ)
     zeek_print_summary()
     spicy_print_summary()
 
+    #Fetch none tested zeek versions resulting in build errors
+    if (ZEEK-SPICY_PLUGIN_VERSION VERSION_GREATER "6.0.3")
+        message(NOTICE "!- Zeek versions greater than 6.0.3 are not tested and might fail")
+    endif ()
+
+    #Fetch none tested spicy versions resulting in build errors
+    if (SPICY_PLUGIN_VERSION VERSION_GREATER "1.8.1")
+        message(NOTICE "!- Spicy versions greater than 1.8.1 might fail to compile the parser successfully")
+
+    #stop iminent reported crash related to specific versions
+        if (SPICY_PLUGIN_VERSION VERSION_EQUAL "1.9.0")
+            message (NOTICE "!- Spicy version 1.9.0 is reported to fail to compile the parser. Please use a different version (E.g. 1.8.1)")
+            message (FATAL_ERROR "Spotted incompatible Spicy version - aborting")
+        endif ()
+
+        if (SPICY_PLUGIN_VERSION VERSION_EQUAL "1.10.0")
+            message (NOTICE "!- Spicy version 1.10.0 is reported to fail to compile the parser. Please use a different version (E.g. 1.8.1)")
+            message (FATAL_ERROR "Spotted incompatible Spicy version - aborting")
+        endif ()
+    endif ()
+
     include(ZeekSpicyAnalyzerSupport)
 endif ()
-
-#Fetch none tested zeek versions resulting in build errors
-if (ZEEK_VERISON VERSION_GREATER "6.0.3")
-    message(NOTICE "Zeek versions greater than 6.0.3 are not tested and might fail to compile the parser successfully")
-
-    #stop iminent reported crash related to specific versions
-    if (ZEEK_VERISON VERSION_EQUAL "6.1.1")
-    message (NOTICE "Zeek version 6.1.1 is reported to fail to compile the parser. Please use a different version (E.g. 6.0.3)."
-    message (FATAL_ERROR "Spotted incompatible Zeek version - aborting")
-    endif
-endif
-
-#Fetch none tested spicy versions resulting in build errors
-if (SPICY_PLUGIN_VERSION VERSION_GREATER "1.8.1")
-    message(NOTICE "Spicy versions greater than 1.8.1 might fail to compile the parser successfully")
-
-    #stop iminent reported crash related to specific versions
-    if (SPICY_PLUGIN_VERSION VERSION_EQUAL "1.9.0")
-        message (NOTICE "Spicy version 1.9.0 is reported to fail to compile the parser. Please use a different version (E.g. 1.8.1)"
-        message (FATAL_ERROR "Spotted incompatible Spicy version - aborting")
-    endif
-endif
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(SpicyPlugin DEFAULT_MSG SPICYZ ZEEK_FOUND)

--- a/IEC60870-5-104/cmake/FindSpicyPlugin.cmake
+++ b/IEC60870-5-104/cmake/FindSpicyPlugin.cmake
@@ -72,24 +72,13 @@ if (SPICYZ)
     spicy_print_summary()
 
     #Fetch none tested zeek versions resulting in build errors
-    if (ZEEK-SPICY_PLUGIN_VERSION VERSION_GREATER "6.0.3")
-        message(NOTICE "!- Zeek versions greater than 6.0.3 are not tested and might fail")
+    if (ZEEK_VERSION VERSION_GREATER "6.2.0")
+        message(NOTICE "!- Zeek versions greater than 6.2.0 are not tested and might fail")
     endif ()
 
     #Fetch none tested spicy versions resulting in build errors
-    if (SPICY_PLUGIN_VERSION VERSION_GREATER "1.8.1")
-        message(NOTICE "!- Spicy versions greater than 1.8.1 might fail to compile the parser successfully")
-
-    #stop iminent reported crash related to specific versions
-        if (SPICY_PLUGIN_VERSION VERSION_EQUAL "1.9.0")
-            message (NOTICE "!- Spicy version 1.9.0 is reported to fail to compile the parser. Please use a different version (E.g. 1.8.1)")
-            message (FATAL_ERROR "Spotted incompatible Spicy version - aborting")
-        endif ()
-
-        if (SPICY_PLUGIN_VERSION VERSION_EQUAL "1.10.0")
-            message (NOTICE "!- Spicy version 1.10.0 is reported to fail to compile the parser. Please use a different version (E.g. 1.8.1)")
-            message (FATAL_ERROR "Spotted incompatible Spicy version - aborting")
-        endif ()
+    if (SPICY_VERSION VERSION_GREATER "1.10.0")
+        message(NOTICE "!- Spicy versions greater than 1.10.0 are not tested and might fail")
     endif ()
 
     include(ZeekSpicyAnalyzerSupport)

--- a/IEC60870-5-104/cmake/FindSpicyPlugin.cmake
+++ b/IEC60870-5-104/cmake/FindSpicyPlugin.cmake
@@ -74,5 +74,27 @@ if (SPICYZ)
     include(ZeekSpicyAnalyzerSupport)
 endif ()
 
+#Fetch none tested zeek versions resulting in build errors
+if (ZEEK_VERISON VERSION_GREATER "6.0.3")
+    message(NOTICE "Zeek versions greater than 6.0.3 are not tested and might fail to compile the parser successfully")
+
+    #stop iminent reported crash related to specific versions
+    if (ZEEK_VERISON VERSION_EQUAL "6.1.1")
+    message (NOTICE "Zeek version 6.1.1 is reported to fail to compile the parser. Please use a different version (E.g. 6.0.3)."
+    message (FATAL_ERROR "Spotted incompatible Zeek version - aborting")
+    endif
+endif
+
+#Fetch none tested spicy versions resulting in build errors
+if (SPICY_PLUGIN_VERSION VERSION_GREATER "1.8.1")
+    message(NOTICE "Spicy versions greater than 1.8.1 might fail to compile the parser successfully")
+
+    #stop iminent reported crash related to specific versions
+    if (SPICY_PLUGIN_VERSION VERSION_EQUAL "1.9.0")
+        message (NOTICE "Spicy version 1.9.0 is reported to fail to compile the parser. Please use a different version (E.g. 1.8.1)"
+        message (FATAL_ERROR "Spotted incompatible Spicy version - aborting")
+    endif
+endif
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(SpicyPlugin DEFAULT_MSG SPICYZ ZEEK_FOUND)

--- a/IEC60870-5-104/scripts/main.zeek
+++ b/IEC60870-5-104/scripts/main.zeek
@@ -81,6 +81,10 @@ export {
 		cp56_year: vector of int &log &optional;
 		cp56_su: vector of bool &log &optional;
 		cp56_valid: vector of bool &log &optional;
+
+		read_cmd: vector of bool &log &optional;
+
+		qrp: vector of string &log &optional;
     };
 
 }
@@ -249,6 +253,16 @@ function set_sva(c: connection){
 function set_vit(c: connection){
 	c$rec$vti_value = vector();
 	c$rec$vti_transient = vector();
+}
+
+# Set value of read_cmd for C_RD_NA_1
+function set_read_cmd(c: connection){
+	c$rec$read_cmd = vector();
+}
+
+# Set Qualifier of reset process (QRP)
+function set_qrp(c: connection){
+	c$rec$qrp = vector();
 }
 
 # APDU event
@@ -827,4 +841,38 @@ event iec60870_5_104::C_CI_NA_1(c: connection, nocounter: bool, group1counter: b
 	c$rec$freeze += freeze;
 	c$rec$reset += reset;
 	c$rec$freezeandreset += freezeandreset;
+}
+
+# Read command
+event iec60870_5_104::C_RD_NA_1(c: connection, read_cmd: bool){
+	if ( !c?$rec ){
+		init_rec(c);
+		c$rec$ioa = vector();
+		set_read_cmd(c);
+	} else {
+		if ( !c$rec?$ioa){
+			c$rec$ioa = vector();
+			set_read_cmd(c);
+		}
+	}
+	c$rec$read_cmd += read_cmd;
+}
+
+# Reset process command
+# event iec60870_5_104::C_RP_NA_1(c: connection, qrp: string){
+event iec60870_5_104::C_RP_NA_1(c: connection, read_cmd: bool, qrp: string){
+	if ( !c?$rec ){
+		init_rec(c);
+		c$rec$ioa = vector();
+		set_qrp(c);
+		set_read_cmd(c);
+	} else {
+		if ( !c$rec?$ioa){
+			c$rec$ioa = vector();
+			set_qrp(c);
+			set_read_cmd(c);
+		}
+	}
+	c$rec$qrp += qrp;
+	c$rec$read_cmd += read_cmd;
 }

--- a/IEC60870-5-104/scripts/main.zeek
+++ b/IEC60870-5-104/scripts/main.zeek
@@ -180,6 +180,12 @@ function set_rco(c: connection){
 	c$rec$select = vector();
 }
 
+# Set Qualifier of set-point command (QOS)
+function set_qos(c: connection){
+	c$rec$execute = vector();
+	c$rec$select = vector();
+}
+
 # Set Bit string of 32 bit (BSI)
 function set_bsi(c: connection){
 	c$rec$bsi = vector();
@@ -726,6 +732,26 @@ event iec60870_5_104::C_RC_NA_1(c: connection, increment: bool, decrement: bool,
 	c$rec$shortpulse += shortpulse;
 	c$rec$longpulse += longpulse;
 	c$rec$persistent += persistent;
+	c$rec$execute += execute;
+	c$rec$select += select;
+}
+
+# Setpoint command, scaled value
+event iec60870_5_104::C_SE_NB_1(c: connection, sva: int, execute: bool, select: bool){
+	if ( !c?$rec ){
+		init_rec(c);
+		c$rec$ioa = vector();
+		set_sva(c);
+		set_qos(c);
+	} else {
+		if ( !c$rec?$ioa){
+			c$rec$ioa = vector();
+			set_sva(c);
+			set_qos(c);
+		}
+	}
+	
+	c$rec$sva += sva;
 	c$rec$execute += execute;
 	c$rec$select += select;
 }

--- a/IEC60870-5-104/scripts/main.zeek
+++ b/IEC60870-5-104/scripts/main.zeek
@@ -859,7 +859,6 @@ event iec60870_5_104::C_RD_NA_1(c: connection, read_cmd: bool){
 }
 
 # Reset process command
-# event iec60870_5_104::C_RP_NA_1(c: connection, qrp: string){
 event iec60870_5_104::C_RP_NA_1(c: connection, read_cmd: bool, qrp: string){
 	if ( !c?$rec ){
 		init_rec(c);


### PR DESCRIPTION
Minor Bug fixes for the IEC60870-5-104 parser

- Utilizing for the new function GH-1468 introduced in [Spicy 1.9.0](https://docs.zeek.org/projects/spicy/en/latest/release-notes.html#version-1-9)
- Parser (should) now work with Spicy versions 1.9.0 and later

Parser was (partially) tested on Zeek 6.2.0 with Spicy 1.10.0
