### PR TITLE
 Tested and integrated ASDU Types C_SE_NB_1, M_BO_TB_1, C_RD_NA_1 and C_RP_NA_1

### DIFF
--- a/IEC60870-5-104/analyzer/iec60870_5_104.evt
+++ b/IEC60870-5-104/analyzer/iec60870_5_104.evt
@@ -56,3 +56,8 @@ on IEC60870_5_104::IE if ( asdu_id==70 ) -> event iec60870_5_104::M_EI_NA_1($con
 on IEC60870_5_104::IE if ( asdu_id==100 ) -> event iec60870_5_104::C_IC_NA_1($conn, self.qoi.stationinterrogation, self.qoi.qoi);
 
 on IEC60870_5_104::IE if ( asdu_id==101 ) -> event iec60870_5_104::C_CI_NA_1($conn, self.qcc.nocounter, self.qcc.group1counter, self.qcc.group2counter, self.qcc.group3counter, self.qcc.group4counter, self.qcc.generalcounter, self.qcc.readonly, self.qcc.freeze, self.qcc.reset, self.qcc.freezeandreset);
+
+on IEC60870_5_104::IE if ( asdu_id==102 ) -> event iec60870_5_104::C_RD_NA_1($conn, self.read_cmd);
+
+#on IEC60870_5_104::IE if ( asdu_id==105 ) -> event iec60870_5_104::C_RP_NA_1($conn, self.qrp.qrp);
+on IEC60870_5_104::IE if ( asdu_id==105 ) -> event iec60870_5_104::C_RP_NA_1($conn, self.read_cmd_2, self.qrp.qrp);

--- a/IEC60870-5-104/analyzer/iec60870_5_104.evt
+++ b/IEC60870-5-104/analyzer/iec60870_5_104.evt
@@ -45,6 +45,8 @@ on IEC60870_5_104::IE if ( asdu_id==46 ) -> event iec60870_5_104::C_DC_NA_1($con
 
 on IEC60870_5_104::IE if ( asdu_id==47 ) -> event iec60870_5_104::C_RC_NA_1($conn, self.rco.increment, self.rco.decrement, self.rco.notallowed0, self.rco.notallowed3, self.rco.shortpulse, self.rco.longpulse, self.rco.persistent, self.rco.execute, self.rco.select);
 
+on IEC60870_5_104::IE if ( asdu_id==49 ) -> event iec60870_5_104::C_SE_NB_1($conn, self.sva.sva, self.qos.execute, self.qos.select);
+
 on IEC60870_5_104::IE if ( asdu_id==51 ) -> event iec60870_5_104::C_BO_NA_1($conn, self.bsi.bits);
 
 #on IEC60870_5_104::IE if ( asdu_id==64 ) -> event iec60870_5_104::C_BO_TA_1($conn, self.bsi.bits, self.cp56time.minutes, self.cp56time.hours, self.cp56time.day, self.cp56time.dow, self.cp56time.month, self.cp56time.year, self.cp56time.su, self.cp56time.valid);

--- a/IEC60870-5-104/analyzer/iec60870_5_104.spicy
+++ b/IEC60870-5-104/analyzer/iec60870_5_104.spicy
@@ -649,7 +649,6 @@ type IE = unit (asdu_id: uint8) {
 		}
 
 		# Get reset process command (C_RP_NA_1) --> not tested!
-		# Is that C_RP_NA_1 or C_RP_NC_1?
 		asdu_type::C_RP_NA_1 -> {
 
 			var read_cmd_2: bool = True;

--- a/IEC60870-5-104/analyzer/iec60870_5_104.spicy
+++ b/IEC60870-5-104/analyzer/iec60870_5_104.spicy
@@ -649,7 +649,10 @@ type IE = unit (asdu_id: uint8) {
 		}
 
 		# Get reset process command (C_RP_NA_1) --> not tested!
+		# Is that C_RP_NA_1 or C_RP_NC_1?
 		asdu_type::C_RP_NA_1 -> {
+
+			var read_cmd_2: bool = True;
 
 			# Qualifier of reset process command
 			qrp: QRP;

--- a/IEC60870-5-104/scripts/main.zeek
+++ b/IEC60870-5-104/scripts/main.zeek
@@ -81,6 +81,10 @@ export {
 		cp56_year: vector of int &log &optional;
 		cp56_su: vector of bool &log &optional;
 		cp56_valid: vector of bool &log &optional;
+
+		read_cmd: vector of bool &log &optional;
+
+		qrp: vector of string &log &optional;
     };
 
 }
@@ -249,6 +253,16 @@ function set_sva(c: connection){
 function set_vit(c: connection){
 	c$rec$vti_value = vector();
 	c$rec$vti_transient = vector();
+}
+
+# Set value of read_cmd for C_RD_NA_1
+function set_read_cmd(c: connection){
+	c$rec$read_cmd = vector();
+}
+
+# Set Qualifier of reset process (QRP)
+function set_qrp(c: connection){
+	c$rec$qrp = vector();
 }
 
 # APDU event
@@ -827,4 +841,38 @@ event iec60870_5_104::C_CI_NA_1(c: connection, nocounter: bool, group1counter: b
 	c$rec$freeze += freeze;
 	c$rec$reset += reset;
 	c$rec$freezeandreset += freezeandreset;
+}
+
+# Read command
+event iec60870_5_104::C_RD_NA_1(c: connection, read_cmd: bool){
+	if ( !c?$rec ){
+		init_rec(c);
+		c$rec$ioa = vector();
+		set_read_cmd(c);
+	} else {
+		if ( !c$rec?$ioa){
+			c$rec$ioa = vector();
+			set_read_cmd(c);
+		}
+	}
+	c$rec$read_cmd += read_cmd;
+}
+
+# Reset process command
+# event iec60870_5_104::C_RP_NA_1(c: connection, qrp: string){
+event iec60870_5_104::C_RP_NA_1(c: connection, read_cmd: bool, qrp: string){
+	if ( !c?$rec ){
+		init_rec(c);
+		c$rec$ioa = vector();
+		set_qrp(c);
+		set_read_cmd(c);
+	} else {
+		if ( !c$rec?$ioa){
+			c$rec$ioa = vector();
+			set_qrp(c);
+			set_read_cmd(c);
+		}
+	}
+	c$rec$qrp += qrp;
+	c$rec$read_cmd += read_cmd;
 }

--- a/IEC60870-5-104/scripts/main.zeek
+++ b/IEC60870-5-104/scripts/main.zeek
@@ -180,6 +180,12 @@ function set_rco(c: connection){
 	c$rec$select = vector();
 }
 
+# Set Qualifier of set-point command (QOS)
+function set_qos(c: connection){
+	c$rec$execute = vector();
+	c$rec$select = vector();
+}
+
 # Set Bit string of 32 bit (BSI)
 function set_bsi(c: connection){
 	c$rec$bsi = vector();
@@ -726,6 +732,26 @@ event iec60870_5_104::C_RC_NA_1(c: connection, increment: bool, decrement: bool,
 	c$rec$shortpulse += shortpulse;
 	c$rec$longpulse += longpulse;
 	c$rec$persistent += persistent;
+	c$rec$execute += execute;
+	c$rec$select += select;
+}
+
+# Setpoint command, scaled value
+event iec60870_5_104::C_SE_NB_1(c: connection, sva: int, execute: bool, select: bool){
+	if ( !c?$rec ){
+		init_rec(c);
+		c$rec$ioa = vector();
+		set_sva(c);
+		set_qos(c);
+	} else {
+		if ( !c$rec?$ioa){
+			c$rec$ioa = vector();
+			set_sva(c);
+			set_qos(c);
+		}
+	}
+	
+	c$rec$sva += sva;
 	c$rec$execute += execute;
 	c$rec$select += select;
 }

--- a/IEC60870-5-104/scripts/main.zeek
+++ b/IEC60870-5-104/scripts/main.zeek
@@ -859,7 +859,6 @@ event iec60870_5_104::C_RD_NA_1(c: connection, read_cmd: bool){
 }
 
 # Reset process command
-# event iec60870_5_104::C_RP_NA_1(c: connection, qrp: string){
 event iec60870_5_104::C_RP_NA_1(c: connection, read_cmd: bool, qrp: string){
 	if ( !c?$rec ){
 		init_rec(c);


### PR DESCRIPTION
Dear team,

This PR adds some Spicy events and parsing for C_SE_NB_1, M_BO_TB_1, C_RD_NA_1 and C_RP_NA_1. These have been tested using the following PCAPs:

"20200608_UOWM_IEC104_Dataset_mitm_drop" 
"20200605_UOWM_IEC104_Dataset_c_rd_na_1"
"20200606_UOWM_IEC104_Dataset_c_rp_na_1"

in: [https://zenodo.org/record/7108614#.ZFR6oJHML0o](https://zenodo.org/record/7108614#.ZFR6oJHML0o)

Let me know if there is any ambiguity regarding any of the parsed fields and I will adjust them.

George.